### PR TITLE
Update src-dirs to include clojurescript as well.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [prismatic/schema "0.3.7"]]
   :plugins [[com.cemerick/clojurescript.test "0.3.3"]
             [lein-cljsbuild "1.0.3"]]
-  :source-paths ["src/clj"]
+  :source-paths ["src/clj" "src/cljs"]
   :test-paths ["test/clj"]
   :cljsbuild {:test-commands {"unit" ["node" :node-runner
                                       "this.literal_js_was_evaluated=true"


### PR DESCRIPTION
If you unpack the jar in clojars right now, you can see that there's no clojurescript source included, or js. 

Earls-MacBook-Pro:schema-transit-0.2.2 earljstsauver$ tree .
```
├── META-INF
│   ├── MANIFEST.MF
│   ├── leiningen
│   │   └── com.outpace
│   │       └── schema-transit
│   │           ├── README.md
│   │           └── project.clj
│   └── maven
│       └── com.outpace
│           └── schema-transit
│               ├── pom.properties
│               └── pom.xml
├── clojure.transit
├── clojurescript.transit
├── outpace
│   ├── schema_transit
│   │   └── macros.clj
│   └── schema_transit.clj
├── project.clj
└── test-output
    └── clojure.transit
```
This change adds the appropriate source files to the jar/source-paths.